### PR TITLE
🔒 Remove install-tl-unx.tar.gz binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ env/
 # IDE
 .vscode/
 .idea/
+
+# Archives
+*.tar.gz
+*.tgz


### PR DESCRIPTION
Removed `install-tl-unx.tar.gz` and updated `.gitignore`.
🎯 **What:** Removed the large binary file `install-tl-unx.tar.gz` from the repository.
⚠️ **Risk:** Storing large binaries in the repository increases clone times and can lead to repository bloat. It also poses a security risk if the binary is compromised or outdated.
🛡️ **Solution:** Removed the file and added `*.tar.gz` and `*.tgz` to `.gitignore` to prevent re-introduction. The build process (GitHub Actions) already obtains TeX Live from a trusted source, so no functionality is lost.

---
*PR created automatically by Jules for task [11990183366460892532](https://jules.google.com/task/11990183366460892532) started by @abdelkrimkr*