### PR TITLE
fix: remove unsupported -biber flag from latexmk command

### DIFF
--- a/latex_paper_project/compile_latex.py
+++ b/latex_paper_project/compile_latex.py
@@ -33,7 +33,6 @@ def compile_pdf():
             "latexmk",
             "-pdf",
             "-pdflatex=pdflatex -interaction=nonstopmode -file-line-error",
-            "-biber",
             f"{main_tex_file}.tex"
         ]
         subprocess.run(latexmk_command, check=True, capture_output=True, text=True)

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,0 +1,33 @@
+import sys
+import os
+import unittest
+from unittest.mock import patch, ANY
+
+# Add the directory to sys.path to import compile_latex
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'latex_paper_project')))
+import compile_latex
+
+class TestCompileLatexArgs(unittest.TestCase):
+    @patch('subprocess.run')
+    def test_latexmk_args(self, mock_run):
+        # Setup mock to succeed
+        mock_run.return_value.returncode = 0
+
+        # Run function
+        compile_latex.compile_pdf()
+
+        # Check arguments
+        mock_run.assert_called_once()
+        args, kwargs = mock_run.call_args
+        command_list = args[0]
+
+        # Print command list for debugging/verification
+        print(f"Command list: {command_list}")
+
+        # Assertions
+        self.assertIn("latexmk", command_list)
+        self.assertIn("-pdf", command_list)
+        self.assertNotIn("-biber", command_list, "Should not contain -biber after fix")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Removed the `-biber` flag from `compile_latex.py` as it is not a valid `latexmk` option and can cause compilation errors. `latexmk` automatically handles bibliography backend detection. Added a test case to verify the fix.

---
*PR created automatically by Jules for task [16439102268295737317](https://jules.google.com/task/16439102268295737317) started by @abdelkrimkr*